### PR TITLE
Add option to change permissions on upload dir

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -27,6 +27,7 @@ RUN yarn install --production=true --pure-lockfile
 FROM base
 ARG UID=10000
 ENV NODE_ENV=production
+ENV UPLOADS_MODE=0700
 
 COPY --chown=$UID --from=builder /hedgedoc /hedgedoc
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -27,6 +27,7 @@ RUN yarn install --production=true --pure-lockfile
 FROM base
 ARG UID=10000
 ENV NODE_ENV=production
+ENV UPLOADS_MODE=0700
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y gosu && \

--- a/resources/docker-entrypoint.sh
+++ b/resources/docker-entrypoint.sh
@@ -30,7 +30,7 @@ fi
 if [ "$UID" -eq 0 ] && [ "$CMD_IMAGE_UPLOAD_TYPE" = "filesystem" ]; then
     if [ "$UID" -eq 0 ]; then
         chown -R hedgedoc ./public/uploads
-        chmod 700 ./public/uploads
+        chmod -R $UPLOADS_MODE ./public/uploads
     else
         echo "
             #################################################################


### PR DESCRIPTION
Since some people serve their static data by uploads directory, unhandy
to set the permissions of the upload directory to 0700 by default.

In order to allow everyone to set the permissions themselves, an option
`UPLOADS_MODE` is introduced that will allow to define the default mode
set to the directory.

Fixes #25 