### PR TITLE
Security issue: data leak to imgur

### DIFF
--- a/resources/config.json
+++ b/resources/config.json
@@ -9,7 +9,6 @@
             "host": "hackmdPostgres",
             "port": "5432",
             "dialect": "postgres"
-        },
-        "imageUploadType": "imgur"
+        }
     }
 }


### PR DESCRIPTION
Defaulting to imgur as file upload is misleading: the CodeMD documentation says that "filesystem" is the default for "imageUploadType".

That's a security issue. Anyone starting this container would expect file upload to work this way, and not send any private data to imgur or any random website.