### PR TITLE
run npm start instead of node app.js

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -99,4 +99,4 @@ EXPOSE 3000
 COPY ["resources/docker-entrypoint.sh", "/usr/local/bin/docker-entrypoint.sh"]
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
-CMD ["node", "app.js"]
+CMD ["npm", "start"]

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -99,4 +99,4 @@ COPY ["resources/docker-entrypoint.sh", "/usr/local/bin/docker-entrypoint.sh"]
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
-CMD ["node", "app.js"]
+CMD ["npm", "start"]


### PR DESCRIPTION
I had some issues when migrating from a docker-based environment to a native deployment due to missiond db-migrations. Therefor the docker-container now runs `npm start` (which applies migrations) instead of `node app.js`. 

The current behaviour would also break when upgrading tu 2.0 because of codimd/server#324 .