### PR TITLE
Update tmpfs definitions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,8 +58,7 @@ services:
     #memswap_limit: 512mb     # version 2 only
     #read_only: true          # not supported in swarm mode, enable along with tmpfs
     #tmpfs:
-    #  - /tmp:size=512K
-    #  - /codimd/tmp:size=1M
+    #  - /tmp:size=10M
     #  # Make sure you remove this when you use filesystem as upload type
     #  - /codimd/public/uploads:size=10M
     environment:


### PR DESCRIPTION
`/codimd/tmp` isn't used anymore for quite a while. We use the system
temp directory these days. This patch updates them and gives a larger
size to the tmpfs as it might be used to cache updates depending on the
upload provider user.