### PR TITLE
Rename HackMD and CodiMD to HedgeDoc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run tests
+name: Tests
 on:
   pull_request:
     branches: '**'

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
-CodiMD container
+HedgeDoc container
 ===
 
-[![Build Status](https://travis-ci.org/codimd/container.svg?branch=master)](https://travis-ci.org/codimd/container)
-[![#CodiMD on matrix.org](https://img.shields.io/badge/Matrix.org-%23CodiMD@matrix.org-green.svg)](https://riot.im/app/#/room/#codimd:matrix.org)
-[![Try in PWD](https://cdn.rawgit.com/play-with-docker/stacks/cff22438/assets/images/button.png)](http://play-with-docker.com?stack=https://github.com/codimd/container/raw/master/docker-compose.yml&stack_name=codimd)
+![Test status](https://github.com/hedgedoc/container/workflows/Tests/badge.svg)
+[![#hedgedoc on matrix.org](https://img.shields.io/badge/Matrix.org-%23hedgedoc@matrix.org-green.svg)](https://chat.hedgedoc.org)
+[![Try in PWD](https://cdn.rawgit.com/play-with-docker/stacks/cff22438/assets/images/button.png)](http://play-with-docker.com?stack=https://github.com/hedgedoc/container/raw/master/docker-compose.yml&stack_name=hedgedoc)
 
-**Debian based version:**
+HedgeDoc docker images are available in two flavors: Debian and Alpine. These are available at quay.io:
 
-[![Docker Repository on Quay](https://quay.io/repository/codimd/server/status "Docker Repository on Quay")](https://quay.io/repository/codimd/server)
+<https://quay.io/repository/hedgedoc/hedgedoc>
 
-Main docker image based on Debian and used by default in the `docker-compose.yml`. Recommended for test and production deployments.
+```
+docker pull quay.io/hedgedoc/hedgedoc:1.6.0-debian
+docker pull quay.io/hedgedoc/hedgedoc:1.6.0-alpine
+```
 
-**Alpine based version:**
-
-[![Docker Repository on Quay](https://quay.io/repository/codimd/server/status "Docker Repository on Quay")](https://quay.io/repository/codimd/server)
-
-Minimal docker image based on Alpine can be used for expert setups. In order to prevent crashes due to dependency problems, this version comes without PDF export.
+We recommend using the Debian version for production deployments and Alpine for expert setups.
 
 # Prerequisite
+
 * git (https://git-scm.com/)
 * docker (https://www.docker.com/community-edition)
 * docker-compose (https://docs.docker.com/compose/install/)
@@ -30,8 +30,8 @@ See more here: https://docs.docker.com/
 ## Get started
 
 1. Install docker and docker-compose, "Docker for Windows" or "Docker for Mac"
-2. Run `git clone https://github.com/codimd/container.git codimd-container`
-3. Change to the directory `codimd-container` directory
+2. Run `git clone https://github.com/hedgedoc/container.git hedgedoc-container`
+3. Change to the directory `hedgedoc-container` directory
 4. Run `docker-compose up` in your terminal
 5. Wait until see the log `HTTP Server listening at port 3000`, it will take few minutes based on your internet connection.
 6. Open http://127.0.0.1:3000
@@ -42,7 +42,7 @@ See more here: https://docs.docker.com/
 Start your docker and enter the terminal, follow below commands:
 
 ```bash
-cd codimd-container ## enter the directory
+cd hedgedoc-container ## enter the directory
 git pull ## pull new commits
 docker-compose pull ## pull new containers
 docker-compose up ## turn on
@@ -50,34 +50,16 @@ docker-compose up ## turn on
 
 ### Migrate from docker-hackmd
 
-If you used the [`docker-hackmd`](https://github.com/hackmdio/docker-hackmd) repository before, migrating to [`codimd-container`](https://github.com/codimd/container) is easy.
+If you used the [`docker-hackmd`](https://github.com/hackmdio/docker-hackmd) repository before, migrating to [`hedgedoc-container`](https://github.com/hedgedoc/container) is easy.
 
-Since codimd-container is basically a fork of `docker-hackmd`, all you need to do is replacing the upstream URL.
+Since `hedgedoc-container` is basically a fork of `docker-hackmd`, all you need to do is replace the upstream URL:
 
 ```bash
-git remote set-url origin https://github.com/codimd/container.git
+git remote set-url origin https://github.com/hedgedoc/container.git
 git pull
 ```
 
 Now you can follow the regular update steps.
-
-### [migration-to-0.5.0](https://github.com/hackmdio/migration-to-0.5.0)
-
-
-We don't use LZString to compress socket.io data and DB data after version 0.5.0.
-Please run the migration tool if you're upgrading from the old version.
-
-1. Stop your CodiMD containers
-2. Modify `docker-compose.yml`, add expose ports `5432` to `hackmdPostgres`
-3. `docker-compose up` to start your codimd containers
-4. Backup DB (see below)
-5. Git clone above `migration-to-0.5.0` and `npm install` (see more on above link)
-6. Modify `config.json` in `migration-to-0.5.0`, change its `username`, `password` and `host` to your docker
-7. Run migration (see more on above link)
-8. Stop your codimd containers
-9. Modify `docker-compose.yml`, remove expose ports `5432` in `hackmdPostgres`
-10. git pull in `codimd-container`, update to version 0.5.0 (see below)
-
 
 
 ## Backup
@@ -85,7 +67,7 @@ Please run the migration tool if you're upgrading from the old version.
 Start your docker and enter the terminal, follow below commands:
 
 ```bash
- docker-compose exec database pg_dump hackmd -U hackmd  > backup.sql
+ docker-compose exec database pg_dump hedgedoc -U hedgedoc > backup.sql
 ```
 
 
@@ -95,26 +77,26 @@ Before starting the application for the first time, run these commands:
 
 ```bash
 docker-compose up -d database
-cat backup.sql | docker exec -i $(docker-compose ps -q database) psql -U hackmd
+cat backup.sql | docker exec -i $(docker-compose ps -q database) psql -U hedgedoc
 ```
-
-# Kubernetes
-
-To install use `helm install stable/hackmd`.
-
-For all further details, please check out the offical HackMD  [K8s helm chart](https://github.com/kubernetes/charts/tree/master/stable/hackmd).
 
 # Custom build
 
-The default setting would use pre-build docker image, if you want to build your own containers
-uncomment the `build` section in the [`docker-compose.yml`](https://github.com/codimd/container/blob/master/docker-compose.yml) and edit the [`config.json`](https://github.com/codimd/container/blob/master/resources/config.json).
+The default setting is to use pre-built docker images. If you want to build your
+own containers uncomment the `build` section in the
+[`docker-compose.yml`](https://github.com/hedgedoc/container/blob/master/docker-compose.yml)
+and edit the
+[`config.json`](https://github.com/hedgedoc/container/blob/master/resources/config.json).
 
-If you change the database settings and don't use the `HMD_DB_URL` make sure you edit the [`.sequelizerc`](https://github.com/codimd/container/blob/master/resources/.sequelizerc).
+If you change the database settings and don't use the `CMD_DB_URL` make sure
+you edit the
+[`.sequelizerc`](https://github.com/hedgedoc/container/blob/master/resources/.sequelizerc).
 
 
 # License
 
-View [license information](https://github.com/codimd/server) for the software contained in this image.
+View [license information](https://github.com/hedgedoc/hedgedoc) for the
+software contained in this image.
 
 
 # Supported Docker versions
@@ -123,21 +105,27 @@ This image is officially supported on Docker version 17.03.1-CE.
 
 Support for older versions (down to 1.12) is provided on a best-effort basis.
 
-Please see [the Docker installation documentation](https://docs.docker.com/installation/) for details on how to upgrade your Docker daemon.
+Please see [the Docker installation
+documentation](https://docs.docker.com/installation/) for details on how to
+upgrade your Docker daemon.
 
 
 # User Feedback
 
 ## Issues
 
-If you have any problems with or questions about this image, please contact us through a [GitHub issue](https://github.com/codimd/container/issues).
+If you have any problems with or questions about this image, please contact us
+through a [GitHub issue](https://github.com/hedgedoc/container/issues).
 
-You can also reach many of the project maintainers via our [`#codimd:matrix.org`](https://matrix.to/#/#codimd:matrix.org).
+You can also reach many of the project maintainers via our matrix room
+[`#hedgedoc:matrix.org`](https://chat.hedgedoc.org).
 
 
 ## Contributing
 
-You are invited to contribute new features, fixes, or updates, large or small; we are always thrilled to receive pull requests, and do our best to process them as fast as we can.
+You are invited to contribute new features, fixes, or updates, large or small;
+we are always thrilled to receive pull requests, and do our best to process
+them as fast as we can.
 
 
-**Happy CodiMD :smile:**
+**Happy HedgeDoc :smile:**

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,16 +1,19 @@
 FROM node:12.19.1-alpine
 
 # Build arguments to change source url, branch or tag
-ARG CODIMD_REPOSITORY=https://github.com/codimd/server.git
+ARG HEDGEDOC_REPOSITORY=https://github.com/hedgedoc/hedgedoc.git
 ARG VERSION=master
 ARG UID=10000
+
+ARG CODIMD_REPOSITORY
+RUN if [ -n "${CODIMD_REPOSITORY}" ]; then echo "CODIMD_REPOSITORY is deprecated. Please use HEDGEDOC_REPOSITORY instead" && exit 1; fi
 
 # Set some default config variables
 ENV DOCKERIZE_VERSION=v0.6.1
 ENV NODE_ENV=production
 
 # Disable PDF export on alpine
-# PhantomJS is broken on alpine and crashes CodiMD
+# PhantomJS is broken on alpine and crashes HedgeDoc
 ENV CMD_ALLOW_PDF_EXPORT=false
 
 RUN apk add --no-cache --virtual .download \
@@ -35,23 +38,24 @@ RUN apk add --no-cache --virtual .dep \
     apk add --no-cache --no-progress --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
       gosu && \
     # Clone the source
-    git clone --depth 1 --branch "$VERSION" "$CODIMD_REPOSITORY" /codimd && \
+    git clone --depth 1 --branch "$VERSION" "$HEDGEDOC_REPOSITORY" /hedgedoc && \
+    ln -s /hedgedoc /codimd && \
     # Print the cloned version and clean up git files
-    cd /codimd && \
+    cd /hedgedoc && \
     git log --pretty=format:'%ad %h %d' --abbrev-commit --date=short -1 && echo && \
     git rev-parse HEAD > /tmp/gitref && \
-    rm -rf /codimd/.git && \
+    rm -rf /hedgedoc/.git && \
     # Mime the git repository for fullversion
-    mkdir /codimd/.git && \
-    mv /tmp/gitref /codimd/.git/HEAD && \
-    jq ".repository.url = \"${CODIMD_REPOSITORY}\"" /codimd/package.json > /codimd/package.new.json && \
-    mv /codimd/package.new.json /codimd/package.json && \
+    mkdir /hedgedoc/.git && \
+    mv /tmp/gitref /hedgedoc/.git/HEAD && \
+    jq ".repository.url = \"${HEDGEDOC_REPOSITORY}\"" /hedgedoc/package.json > /hedgedoc/package.new.json && \
+    mv /hedgedoc/package.new.json /hedgedoc/package.json && \
     \
     # Symlink configuration files
-    rm -f /codimd/config.json && \
-    ln -s /files/config.json /codimd/config.json && \
-    rm -f /codimd/.sequelizerc && \
-    ln -s /files/.sequelizerc /codimd/.sequelizerc && \
+    rm -f /hedgedoc/config.json && \
+    ln -s /files/config.json /hedgedoc/config.json && \
+    rm -f /hedgedoc/.sequelizerc && \
+    ln -s /files/.sequelizerc /hedgedoc/.sequelizerc && \
     \
     # Install NPM dependencies and build project
     yarn install --pure-lockfile && \
@@ -64,10 +68,10 @@ RUN apk add --no-cache --virtual .dep \
     yarn cache clean && \
     apk del .dep && \
     \
-    adduser -u $UID -h /codimd/ -D -S codimd && \
-    chown -R codimd /codimd/
+    adduser -u $UID -h /hedgedoc/ -D -S hedgedoc && \
+    chown -R hedgedoc /hedgedoc/
 
-WORKDIR /codimd
+WORKDIR /hedgedoc
 EXPOSE 3000
 
 COPY ["resources/docker-entrypoint.sh", "/usr/local/bin/docker-entrypoint.sh"]

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,9 +1,12 @@
 FROM node:12.19.1-slim
 
 # Build arguments to change source url, branch or tag
-ARG CODIMD_REPOSITORY=https://github.com/codimd/server.git
+ARG HEDGEDOC_REPOSITORY=https://github.com/hedgedoc/hedgedoc.git
 ARG VERSION=master
 ARG UID=10000
+
+ARG CODIMD_REPOSITORY
+RUN if [ -n "${CODIMD_REPOSITORY}" ]; then echo "CODIMD_REPOSITORY is deprecated. Please use HEDGEDOC_REPOSITORY instead" && exit 1; fi
 
 # Set some default config variables
 ARG DEBIAN_FRONTEND=noninteractive
@@ -37,24 +40,25 @@ RUN export dev_apt=( \
       gosu && \
     \
     # Clone the source
-    git clone --depth 1 --branch "$VERSION" "$CODIMD_REPOSITORY" /codimd && \
+    git clone --depth 1 --branch "$VERSION" "$HEDGEDOC_REPOSITORY" /hedgedoc && \
+    ln -s /hedgedoc /codimd && \
     # Print the cloned version and clean up git files
-    cd /codimd && \
+    cd /hedgedoc && \
     git log --pretty=format:'%ad %h %d' --abbrev-commit --date=short -1 && echo && \
     git rev-parse HEAD > /tmp/gitref && \
-    rm -rf /codimd/.git && \
+    rm -rf /hedgedoc/.git && \
     \
     # Mime the git repository for fullversion
-    mkdir /codimd/.git && \
-    mv /tmp/gitref /codimd/.git/HEAD && \
-    jq ".repository.url = \"${CODIMD_REPOSITORY}\"" /codimd/package.json > /codimd/package.new.json && \
-    mv /codimd/package.new.json /codimd/package.json && \
+    mkdir /hedgedoc/.git && \
+    mv /tmp/gitref /hedgedoc/.git/HEAD && \
+    jq ".repository.url = \"${HEDGEDOC_REPOSITORY}\"" /hedgedoc/package.json > /hedgedoc/package.new.json && \
+    mv /hedgedoc/package.new.json /hedgedoc/package.json && \
     \
     # Symlink configuration files
-    rm -f /codimd/config.json && \
-    ln -s /files/config.json /codimd/config.json && \
-    rm -f /codimd/.sequelizerc && \
-    ln -s /files/.sequelizerc /codimd/.sequelizerc && \
+    rm -f /hedgedoc/config.json && \
+    ln -s /files/config.json /hedgedoc/config.json && \
+    rm -f /hedgedoc/.sequelizerc && \
+    ln -s /files/.sequelizerc /hedgedoc/.sequelizerc && \
     \
     # Install NPM dependencies and build project
     yarn install --pure-lockfile && \
@@ -66,11 +70,11 @@ RUN export dev_apt=( \
     yarn cache clean && \
     apt-get autoremove --purge -qy "${dev_apt[@]}" && \
     rm -r /var/lib/apt/lists/* && \
-    # Create codimd user
-    adduser --uid $UID --home /codimd/ --disabled-password --system codimd && \
-    chown -R codimd /codimd/
+    # Create hedgedoc user
+    adduser --uid $UID --home /hedgedoc/ --disabled-password --system hedgedoc && \
+    chown -R hedgedoc /hedgedoc/
 
-WORKDIR /codimd
+WORKDIR /hedgedoc
 EXPOSE 3000
 
 COPY ["resources/docker-entrypoint.sh", "/usr/local/bin/docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,9 @@ services:
     #  - /run/postgresql:size=512K
     #  - /tmp:size=256K
     environment:
-      - POSTGRES_USER=hackmd
-      - POSTGRES_PASSWORD=hackmdpass
-      - POSTGRES_DB=hackmd
+      - POSTGRES_USER=hedgedoc
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=hedgedoc
     volumes:
       - database:/var/lib/postgresql/data
     networks:
@@ -31,14 +31,14 @@ services:
   #    # should have a backup
   #    image: mariadb:10
   #    environment:
-  #      - MYSQL_USER=hackmd
-  #      - MYSQL_PASSWORD=hackmdpass
-  #      - MYSQL_DATABASE=hackmd
+  #      - MYSQL_USER=hedgedoc
+  #      - MYSQL_PASSWORD=password
+  #      - MYSQL_DATABASE=hedgedoc
   #      - MYSQL_ALLOW_EMPTY_PASSWORD=true
   #    volumes:
   #      - database:/var/lib/mysql
   #      # This config provides UTF-8 support to the database by default
-  #      # If this config is not used, HackMD breaks as it tries to write
+  #      # If this config is not used, HedgeDoc breaks as it tries to write
   #      # UTF-8 to a latin database.
   #      - ./resources/utf8.cnf:/etc/mysql/conf.d/utf8.cnf
   #    networks:
@@ -52,24 +52,24 @@ services:
     #  dockerfile: debian/Dockerfile
     #  args:
     #    - "VERSION=master"
-    #    - "CODIMD_REPOSITORY=https://github.com/codimd/server.git"
-    image: quay.io/codimd/server:1.6.0
+    #    - "HEDGEDOC_REPOSITORY=https://github.com/hedgedoc/hedgedoc.git"
+    image: quay.io/hedgedoc/hedgedoc:1.6.0
     #mem_limit: 256mb         # version 2 only
     #memswap_limit: 512mb     # version 2 only
     #read_only: true          # not supported in swarm mode, enable along with tmpfs
     #tmpfs:
     #  - /tmp:size=10M
     #  # Make sure you remove this when you use filesystem as upload type
-    #  - /codimd/public/uploads:size=10M
+    #  - /hedgedoc/public/uploads:size=10M
     environment:
       # DB_URL is formatted like: <databasetype>://<username>:<password>@<hostname>:<port>/<database>
       # Other examples are:
-      # - mysql://hackmd:hackmdpass@database:3306/hackmd
+      # - mysql://hedgedoc:password@database:3306/hedgedoc
       # - sqlite:///data/sqlite.db (NOT RECOMMENDED)
       # - For details see the official sequelize docs: http://docs.sequelizejs.com/en/v3/
-      - CMD_DB_URL=postgres://hackmd:hackmdpass@database:5432/hackmd
+      - CMD_DB_URL=postgres://hedgedoc:password@database:5432/hedgedoc
     volumes:
-      - uploads:/codimd/public/uploads
+      - uploads:/hedgedoc/public/uploads
     ports:
       # Ports that are published to the outside.
       # The latter port is the port inside the container. It should always stay on 3000

--- a/resources/config.json
+++ b/resources/config.json
@@ -3,10 +3,10 @@
         "urlAddPort": true,
         "email": true,
         "db": {
-            "username": "hackmd",
-            "password": "hackmdpass",
-            "database": "hackmd",
-            "host": "hackmdPostgres",
+            "username": "hedgedoc",
+            "password": "hedgedocpass",
+            "database": "hedgedoc",
+            "host": "hedgedocPostgres",
             "port": "5432",
             "dialect": "postgres"
         }

--- a/resources/docker-entrypoint.sh
+++ b/resources/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 
 # Use gosu if the container started with root privileges
 UID="$(id -u)"
-[ "$UID" -eq 0 ] && GOSU="gosu codimd" || GOSU=""
+[ "$UID" -eq 0 ] && GOSU="gosu hedgedoc" || GOSU=""
 
 if [ "$HMD_DB_URL" != "" ] && [ "$CMD_DB_URL" = "" ]; then
     CMD_DB_URL="$HMD_DB_URL"
@@ -19,7 +19,7 @@ if [ -f "$DOCKER_SECRET_DB_URL_FILE_PATH" ]; then
 fi
 
 if [ "$CMD_DB_URL" = "" ]; then
-    CMD_DB_URL="postgres://hackmd:hackmdpass@database:5432/hackmd"
+    CMD_DB_URL="postgres://hedgedoc:password@database:5432/hedgedoc"
 fi
 
 export CMD_DB_URL
@@ -53,7 +53,7 @@ $GOSU ./node_modules/.bin/sequelize db:migrate
 # Change owner and permission if filesystem backend is used and user has root permissions
 if [ "$UID" -eq 0 ] && [ "$CMD_IMAGE_UPLOAD_TYPE" = "filesystem" ]; then
     if [ "$UID" -eq 0 ]; then
-        chown -R codimd ./public/uploads
+        chown -R hedgedoc ./public/uploads
         chmod 700 ./public/uploads
     else
         echo "

--- a/tools/tagging.sh
+++ b/tools/tagging.sh
@@ -8,11 +8,11 @@ if [ "$1" = "--help" ]; then
         $0 <PREFIX> <VERSION> <SUFFIX>
 
     Example:
-        $0 codimd 0.5.1 alpine
+        $0 hedgedoc 0.5.1 alpine
     "
 fi
 
-PREFIX=${1:-codimd}
+PREFIX=${1:-hedgedoc}
 VERSION=${2}
 SUFFIX=""
 [ "${3}" != "" ] && [ "${3}" != "debian" ] && SUFFIX="${3}" SUFFIX_FULL="-${SUFFIX}"
@@ -20,13 +20,13 @@ SUFFIX=""
 
 
 if [ "$VERSION" != "" ]; then
-    docker tag codimd:testing "${PREFIX}:$(echo ${VERSION} | cut -d. -f1)${SUFFIX_FULL}"
-    docker tag codimd:testing "${PREFIX}:$(echo ${VERSION} | cut -d. -f1-2)${SUFFIX_FULL}"
-    docker tag codimd:testing "${PREFIX}:$(echo ${VERSION} | cut -d. -f1-3)${SUFFIX_FULL}"
+    docker tag hedgedoc:testing "${PREFIX}:$(echo ${VERSION} | cut -d. -f1)${SUFFIX_FULL}"
+    docker tag hedgedoc:testing "${PREFIX}:$(echo ${VERSION} | cut -d. -f1-2)${SUFFIX_FULL}"
+    docker tag hedgedoc:testing "${PREFIX}:$(echo ${VERSION} | cut -d. -f1-3)${SUFFIX_FULL}"
     if [ "$SUFFIX" = "" ]; then
-        docker tag codimd:testing "$PREFIX:latest"
+        docker tag hedgedoc:testing "$PREFIX:latest"
     else
-        docker tag codimd:testing "$PREFIX:${SUFFIX}"
+        docker tag hedgedoc:testing "$PREFIX:${SUFFIX}"
     fi
 else
     echo "No version provided. Skipping tagging..."


### PR DESCRIPTION
To prepare for the rename, I replaced every occurrence of codimd with
hedgedoc.

There were still some stray hackmd references, so I replaced them as
well.

I removed the kubernetes instructions, since they were referring to
a helm chart that does not exist anymore.

There are two references to hackmd left. The first one is in the
migration guide from hackmd-docker to hedgedoc-container. The other one
is in a migration guide that points to
https://github.com/hackmdio/migration-to-0.5.0. Since this repository
wasn't forked (and there's no license attached), I left the reference as
is.