### PR TITLE
Make container compatible with OCI image format

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -23,15 +23,13 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
 # Add configuraton files
 COPY ["resources/config.json", "resources/.sequelizerc", "/files/"]
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN export dev_apt=( \
-      "bzip2" \
-      "git" \
-      "jq" \
-    ) && \
+RUN export dev_apt="\
+      bzip2 \
+      git \
+      jq" && \
     apt-get update && \
     apt-get install --no-install-recommends -y \
-      "${dev_apt[@]}" \
+      $dev_apt \
       # Add fonts for PDF export
       fonts-noto \
       gosu && \
@@ -64,7 +62,7 @@ RUN export dev_apt=( \
     # Clean up this layer
     yarn install && \
     yarn cache clean && \
-    apt-get autoremove --purge -qy "${dev_apt[@]}" && \
+    apt-get autoremove --purge -qy $dev_apt && \
     rm -r /var/lib/apt/lists/* && \
     # Create codimd user
     adduser --uid $UID --home /codimd/ --disabled-password --system codimd && \


### PR DESCRIPTION
Fixes build instructions to enable building with podman, 
because `SHELL` is not supported in OCI images.

When you try to build this Dockerfile with podman, it results in this error:
`ERRO[0038] SHELL is not supported for OCI image format, [/bin/bash -o pipefail -c] will be ignored. Must use ´docker´ format`

This results in `/bin/sh` being used as the shell instead of `/bin/bash`, thus causing bash arrays to break, leading to this error:
`/bin/sh: 1: Syntax error: "(" unexpected
Error: error building at STEP "RUN export dev_apt=(       "bzip2"       "git"       "jq"     )`

This PR removes the `SHELL` command from the container definition and uses standard variables instead of bash arrays.

These changes should not affect building using Docker negatively, but do enable the container to be build using podman and probably also buildah and others.
