### PR TITLE
Pin digists of base images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    "docker:pinDigests"
   ]
 }


### PR DESCRIPTION
This patch should make sure we don't introduce unexpected breaking
changes into our setup and instead for every upstream upgrade get a new
renovate pull request.