### PR TITLE
Publish nightly docker images

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,45 @@
+name: nightly
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        base: [debian, alpine]
+    env:
+      HEDGEDOC_VERSION: master
+      HEDGEDOC_IMAGE: quay.io/hedgedoc/hedgedoc-nightly
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set date
+        run: echo TODAY=$(date +%Y%m%d) >> $GITHUB_ENV
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to docker registry
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./${{ matrix.base }}/Dockerfile
+          labels: quay.expires-after=1w
+          build-args: |
+            VERSION=${{ env.HEDGEDOC_VERSION }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.HEDGEDOC_IMAGE }}:${{ env.TODAY }}-${{ matrix.base }}


### PR DESCRIPTION
Create and push a docker image based on `hedgedoc/hedgedoc@master` to `quay.io/hedgedoc/hedgedoc:nightly-{alpine,debian}`.