### PR TITLE
Extend renovatebot config to automerge digests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "extends": [
     "config:base",
-    "docker:pinDigests"
+    "docker:pinDigests",
+    ":gitSignOff",
+    ":automergeDigest"
   ]
 }


### PR DESCRIPTION
This patch adds sign-offs to the renovatebot commits and allows them to
be automatically merged to reduce maintenance work.
