### PR TITLE
Fix pin-rebuild-pin loop

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   database:
     # Don't upgrade PostgreSQL by simply changing the version number
     # You need to migrate the Database to the new PostgreSQL version
-    image: postgres:9.6-alpine@sha256:c2b558c811efb0c3d917c0915536b8970ad0c56c2af0dde5620f1bd8187c3e87
+    image: postgres:9.6-alpine
     #mem_limit: 256mb         # version 2 only
     #memswap_limit: 512mb     # version 2 only
     #read_only: true          # not supported in swarm mode please enable along with tmpfs
@@ -53,7 +53,7 @@ services:
     #  args:
     #    - "VERSION=master"
     #    - "HEDGEDOC_REPOSITORY=https://github.com/hedgedoc/hedgedoc.git"
-    image: quay.io/hedgedoc/hedgedoc:1.6.0@sha256:12d91b360fbee8173d942c4167a48a4ac1734994e416e2ce190f55c5d0844fcd
+    image: quay.io/hedgedoc/hedgedoc:1.6.0
     #mem_limit: 256mb         # version 2 only
     #memswap_limit: 512mb     # version 2 only
     #read_only: true          # not supported in swarm mode, enable along with tmpfs

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,11 @@
     "docker:pinDigests",
     ":gitSignOff",
     ":automergeDigest"
+  ],
+  "packageRules": [
+    {
+      "paths": ["+(docker-compose.yml)"],
+      "pinDigests": false
+    }
   ]
 }


### PR DESCRIPTION
This patch should fix the pin-rebuild-pin loop, that appears due to each
change in the repository resulting in a new image build, which results
in a new pin in the docker-compose file, which results in a merge, that
triggers a new build.

Instead this patch excludes the `docker-compose.yaml` from pinning and
solves the issue.