### PR TITLE
Remove all content from config.json

### DIFF
--- a/resources/config.json
+++ b/resources/config.json
@@ -1,14 +1,1 @@
-{
-    "production": {
-        "urlAddPort": true,
-        "email": true,
-        "db": {
-            "username": "hedgedoc",
-            "password": "hedgedocpass",
-            "database": "hedgedoc",
-            "host": "hedgedocPostgres",
-            "port": "5432",
-            "dialect": "postgres"
-        }
-    }
-}
+{}


### PR DESCRIPTION
Because of a bug in sequelize, the hardcoded name of the database in config.json was used with mysql/mariadb databases. This commit removes all content from config.json, so environment variables are always used. The file itself must still exist, as HedgeDoc does not start without a config file.

For details see https://github.com/hedgedoc/container/issues/136#issuecomment-747072862

Closes #136 