### PR TITLE
Improvement/rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ docker pull quay.io/hedgedoc/hedgedoc:1.7.0-debian
 docker pull quay.io/hedgedoc/hedgedoc:1.7.0-alpine
 ```
 
+You can also use the `alpine` or `debian` tag for the latest version.
+
 We recommend using the Debian version for production deployments and Alpine for expert setups.
 
 # Prerequisite

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ HedgeDoc docker images are available in two flavors: Debian and Alpine. These ar
 <https://quay.io/repository/hedgedoc/hedgedoc>
 
 ```
-docker pull quay.io/hedgedoc/hedgedoc:1.6.0-debian
-docker pull quay.io/hedgedoc/hedgedoc:1.6.0-alpine
+docker pull quay.io/hedgedoc/hedgedoc:1.7.0-debian
+docker pull quay.io/hedgedoc/hedgedoc:1.7.0-alpine
 ```
 
 We recommend using the Debian version for production deployments and Alpine for expert setups.


### PR DESCRIPTION
We released 1.7.0, but the README still talks about "1.6.0"