### PR TITLE
Allow CMD_DB_URL without a database port

### DIFF
--- a/resources/docker-entrypoint.sh
+++ b/resources/docker-entrypoint.sh
@@ -27,6 +27,15 @@ export CMD_DB_URL
 DB_SOCKET=$(echo ${CMD_DB_URL} | sed -e 's/.*:\/\//\/\//' -e 's/.*\/\/[^@]*@//' -e 's/\/.*$//')
 
 if [ "$DB_SOCKET" != "" ]; then
+
+    if [ -n "${DB_SOCKET##*:*}" ]; then
+        if [ -z "${CMD_DB_URL##postgres:*}" ]; then
+            DB_SOCKET=$DB_SOCKET:5432
+        elif [ -z "${CMD_DB_URL##mysql:*}" ]; then
+            DB_SOCKET=$DB_SOCKET:3306
+        fi
+    fi
+
     dockerize -wait "tcp://${DB_SOCKET}" -timeout 30s
 fi
 


### PR DESCRIPTION
This allows to install hedgedoc with the codimd helm chart in kubernetes.

Uses the default ports for postgres and mysql while waiting for the database to get ready.

```
Waiting for: tcp://hedgedoc-postgresql
Problem with dial: dial tcp: address hedgedoc-postgresql: missing port in address. Sleeping 1s
```