### PR TITLE
Fix tests by introducing a delay

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.21.0-alpine@sha256:81eec5b1cac69ff6af62097563737b40ac94b605b43d01466c0cf48e220494be AS base
+FROM node:12.22.1-alpine@sha256:9923c9efb13cf7535f67e49b03010f0977a800068e4c8e0e2c93433a6bfa1e77 AS base
 
 FROM base AS basebuilder
 RUN apk update

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.21.0-slim@sha256:718e6d699295749b3bf1e3782821069ab279e37e5d8ddf163aa566a8645891af AS base
+FROM node:12.22.1-slim@sha256:5779929b7bc9952dd592971eb57aa38cb2d0f70709e909a11f2021c812d8e917 AS base
 
 FROM base AS basebuilder
 RUN apt-get update

--- a/tests/chore/startContainer.sh
+++ b/tests/chore/startContainer.sh
@@ -17,3 +17,5 @@ PORT=$(( $(shuf -e $(seq 0 9999) | head -n1) + 10000 ))
 
 # Run container in a simple way
 docker ps -f id=$(docker run -d --name hedgedoc --network postgres -p 127.0.0.1:${PORT}:3000 -e "CMD_DB_URL=postgres://hedgedoc:password@database:5432/hedgedoc" hedgedoc)
+
+sleep 30


### PR DESCRIPTION
This patch should fix current failing builds by adding a 30 seconds
delay between the container starting and the tests starting to run, so
that database migrations and alike can take place.