### PR TITLE
Remove sequelize from entrypoint script and Dockerfile

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -44,7 +44,7 @@ COPY --from=dockerize dockerize /usr/local/bin/
 COPY --chown=$UID --from=builder /hedgedoc /hedgedoc
 
 # Add configuraton files
-COPY ["resources/config.json", "resources/.sequelizerc", "/files/"]
+COPY ["resources/config.json", "/files/"]
 
 # For backwards compatibility
 RUN ln -s /hedgedoc /codimd
@@ -55,8 +55,6 @@ RUN apk add --no-cache --no-progress --repository http://dl-cdn.alpinelinux.org/
 # Symlink configuration files
 RUN rm -f /hedgedoc/config.json
 RUN ln -s /files/config.json /hedgedoc/config.json
-RUN rm -f /hedgedoc/.sequelizerc
-RUN ln -s /files/.sequelizerc /hedgedoc/.sequelizerc
 
 # Create hedgedoc user
 RUN adduser -u $UID -h /hedgedoc/ -D -S hedgedoc

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -50,7 +50,7 @@ COPY --from=dockerize dockerize /usr/local/bin/
 COPY --chown=$UID --from=builder /hedgedoc /hedgedoc
 
 # Add configuraton files
-COPY ["resources/config.json", "resources/.sequelizerc", "/files/"]
+COPY ["resources/config.json", "/files/"]
 
 # For backwards compatibility
 RUN ln -s /hedgedoc /codimd
@@ -58,8 +58,6 @@ RUN ln -s /hedgedoc /codimd
 # Symlink configuration files
 RUN rm -f /hedgedoc/config.json
 RUN ln -s /files/config.json /hedgedoc/config.json
-RUN rm -f /hedgedoc/.sequelizerc
-RUN ln -s /files/.sequelizerc /hedgedoc/.sequelizerc
 
 # Create hedgedoc user
 RUN adduser --uid $UID --home /hedgedoc/ --disabled-password --system hedgedoc

--- a/resources/.sequelizerc
+++ b/resources/.sequelizerc
@@ -1,8 +1,0 @@
-var path = require('path');
-
-module.exports = {
-    'config':          path.resolve('config.json'),
-    'migrations-path': path.resolve('lib', 'migrations'),
-    'models-path':     path.resolve('lib', 'models'),
-    'url':             process.env.CMD_DB_URL
-}

--- a/resources/docker-entrypoint.sh
+++ b/resources/docker-entrypoint.sh
@@ -30,8 +30,6 @@ if [ "$DB_SOCKET" != "" ]; then
     dockerize -wait "tcp://${DB_SOCKET}" -timeout 30s
 fi
 
-$GOSU ./node_modules/.bin/sequelize db:migrate
-
 # Print warning if local data storage is used but no volume is mounted
 [ "$CMD_IMAGE_UPLOAD_TYPE" = "filesystem" ] && { mountpoint -q ./public/uploads || {
     echo "

--- a/tests/version.sh
+++ b/tests/version.sh
@@ -14,7 +14,7 @@ fi
 
 # Check for command existence
 # See: https://www.shivering-isles.com/helpful-shell-snippets-for-docker-testing-and-bootstrapping/
-command_exits() { command -v $1 >/dev/null 2>&1 || { echo >&2 "I require $1 but it's not installed.  Aborting."; exit 1; }; }
+command_exists() { command -v $1 >/dev/null 2>&1 || { echo >&2 "I require $1 but it's not installed.  Aborting."; exit 1; }; }
 
 # Docker latest version tag
 # See: https://www.shivering-isles.com/helpful-shell-snippets-for-docker-testing-and-bootstrapping/
@@ -32,7 +32,7 @@ docker_base_version() { cat "$1" | grep FROM | sed -e "s/FROM.*://g"; }
 # See: https://www.shivering-isles.com/helpful-shell-snippets-for-docker-testing-and-bootstrapping/
 docker_base_name() { cat "$1" | grep FROM | sed -e "s/FROM[^[:alpha:]]//g" -e "s/:.*//g"; }
 
-command_exits wget
+command_exists wget
 
 LATEST=$(docker_image_latest_tag `docker_base_name "$DOCKERFILE"`)
 CURRENT=$(docker_base_version "$DOCKERFILE")


### PR DESCRIPTION
This PR removes the .sequelizerc and calls to sequelize-cli as they are not necessary anymore with 1.8.0.

Also fixed a typo in the tests script.