### PR TITLE
Implement automatic version management for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         base: [debian, alpine]
     env:
+      # renovate: datasource=github-tags depName=hedgedoc/hedgedoc versioning=semver
       HEDGEDOC_VERSION: 1.8.2
       HEDGEDOC_IMAGE: quay.io/hedgedoc/hedgedoc
     steps:

--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,14 @@
       "paths": ["+(docker-compose.yml)"],
       "pinDigests": false
     }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["\\.yml$", "\\.yaml$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s+\\S+:\\s+\"?(?<currentValue>[^\"]*?)\"?\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
   ]
 }


### PR DESCRIPTION
This patch enables renovate to notice new hedgedoc releases and
automatically provide a PR that updates the hedgedoc release version.

This was implemented using the regex-manager that allows to parse
strings and extract the required values for datasource, versioning
schema and project name in order to have them handled by renovatebot.

Reference:
https://docs.renovatebot.com/modules/manager/regex/