### PR TITLE
Remove dockerize and entrypoint-script parsing

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -3,13 +3,6 @@ FROM node:16.6.2-alpine@sha256:2d7a22f6d738af0dc829d181e8a95d6239460a185f2dafee5
 FROM base AS basebuilder
 RUN apk update
 
-FROM basebuilder AS dockerize
-# Download and extract dockerize, used in resources/docker-entrypoint.sh
-ENV DOCKERIZE_VERSION=v0.6.1
-RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-RUN tar -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-RUN rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-
 
 FROM basebuilder AS builder
 # Build arguments to change source url, branch or tag
@@ -40,7 +33,6 @@ FROM base
 ARG UID=10000
 ENV NODE_ENV=production
 
-COPY --from=dockerize dockerize /usr/local/bin/
 COPY --chown=$UID --from=builder /hedgedoc /hedgedoc
 
 # Add configuraton files

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -3,14 +3,6 @@ FROM node:16.6.2-slim@sha256:d2a8dbd9016f66e78ff82dab29633adc56c8f007974a9c63392
 FROM base AS basebuilder
 RUN apt-get update
 
-FROM basebuilder AS dockerize
-# Download and extract dockerize, used in resources/docker-entrypoint.sh
-ENV DOCKERIZE_VERSION=v0.6.1
-RUN apt-get install --no-install-recommends -y ca-certificates wget
-RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-RUN tar -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-RUN rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-
 
 FROM basebuilder AS builder
 # Build arguments to change source url, branch or tag
@@ -46,7 +38,6 @@ RUN apt-get update && \
     apt-get install --no-install-recommends -y fonts-noto gosu && \
     rm -r /var/lib/apt/lists/*
 
-COPY --from=dockerize dockerize /usr/local/bin/
 COPY --chown=$UID --from=builder /hedgedoc /hedgedoc
 
 # Add configuraton files

--- a/resources/docker-entrypoint.sh
+++ b/resources/docker-entrypoint.sh
@@ -4,30 +4,8 @@
 UID="$(id -u)"
 [ "$UID" -eq 0 ] && GOSU="gosu hedgedoc" || GOSU=""
 
-if [ "$HMD_DB_URL" != "" ] && [ "$CMD_DB_URL" = "" ]; then
-    CMD_DB_URL="$HMD_DB_URL"
-fi
-
 if [ "$HMD_IMAGE_UPLOAD_TYPE" != "" ] && [ "$CMD_IMAGE_UPLOAD_TYPE" = "" ]; then
     CMD_IMAGE_UPLOAD_TYPE="$HMD_IMAGE_UPLOAD_TYPE"
-fi
-
-DOCKER_SECRET_DB_URL_FILE_PATH="/run/secrets/dbURL"
-
-if [ -f "$DOCKER_SECRET_DB_URL_FILE_PATH" ]; then
-    CMD_DB_URL="$(cat $DOCKER_SECRET_DB_URL_FILE_PATH)"
-fi
-
-if [ "$CMD_DB_URL" = "" ]; then
-    CMD_DB_URL="postgres://hedgedoc:password@database:5432/hedgedoc"
-fi
-
-export CMD_DB_URL
-
-DB_SOCKET=$(echo ${CMD_DB_URL} | sed -e 's/.*:\/\//\/\//' -e 's/.*\/\/[^@]*@//' -e 's/\/.*$//')
-
-if [ "$DB_SOCKET" != "" ]; then
-    dockerize -wait "tcp://${DB_SOCKET}" -timeout 30s
 fi
 
 # Print warning if local data storage is used but no volume is mounted


### PR DESCRIPTION
Currently the entrypoint script parses the database URL configuration
string in order to extract the remote location and waits for the
database to be available.

This patch removes this logic and also removes `dockerize`, which was
used to wait for the connection. However, this change should not be
merged without the changes introduced in a commit on the main
application, that implements an own connection retry mechanism.

Reference:
https://github.com/hedgedoc/hedgedoc/pull/1228