### PR TITLE
Dockerfile cleanups

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -21,7 +21,6 @@ RUN mv /hedgedoc/package.new.json /hedgedoc/package.json
 WORKDIR /hedgedoc
 RUN yarn install --production=false --pure-lockfile
 RUN yarn run build
-RUN rm -rf node_modules
 RUN yarn install --production=true --pure-lockfile
 
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,10 +1,6 @@
 FROM node:16.6.2-alpine@sha256:2d7a22f6d738af0dc829d181e8a95d6239460a185f2dafee531b3c79b6c9334c AS base
 
-FROM base AS basebuilder
-RUN apk update
-
-
-FROM basebuilder AS builder
+FROM base AS builder
 # Build arguments to change source url, branch or tag
 ARG CODIMD_REPOSITORY
 ARG HEDGEDOC_REPOSITORY=https://github.com/hedgedoc/hedgedoc.git
@@ -12,7 +8,7 @@ ARG VERSION=master
 RUN if [ -n "${CODIMD_REPOSITORY}" ]; then echo "CODIMD_REPOSITORY is deprecated. Please use HEDGEDOC_REPOSITORY instead" && exit 1; fi
 
 # Clone the source and remove git repository but keep the HEAD file
-RUN apk add git jq
+RUN apk update && apk add git jq
 RUN git clone --depth 1 --branch "$VERSION" "$HEDGEDOC_REPOSITORY" /hedgedoc
 RUN git -C /hedgedoc log --pretty=format:'%ad %h %d' --abbrev-commit --date=short -1
 RUN git -C /hedgedoc rev-parse HEAD > /tmp/gitref

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get install --no-install-recommends -y bzip2
 WORKDIR /hedgedoc
 RUN yarn install --production=false --pure-lockfile
 RUN yarn run build
-RUN rm -rf node_modules
 RUN yarn install --production=true --pure-lockfile
 
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,10 +1,6 @@
 FROM node:16.6.2-slim@sha256:d2a8dbd9016f66e78ff82dab29633adc56c8f007974a9c63392e94763423ecf9 AS base
 
-FROM base AS basebuilder
-RUN apt-get update
-
-
-FROM basebuilder AS builder
+FROM base AS builder
 # Build arguments to change source url, branch or tag
 ARG CODIMD_REPOSITORY
 ARG HEDGEDOC_REPOSITORY=https://github.com/hedgedoc/hedgedoc.git
@@ -12,7 +8,7 @@ ARG VERSION=master
 RUN if [ -n "${CODIMD_REPOSITORY}" ]; then echo "CODIMD_REPOSITORY is deprecated. Please use HEDGEDOC_REPOSITORY instead" && exit 1; fi
 
 # Clone the source and remove git repository but keep the HEAD file
-RUN apt-get install --no-install-recommends -y git jq ca-certificates
+RUN apt-get update && apt-get install --no-install-recommends -y git jq ca-certificates
 RUN git clone --depth 1 --branch "$VERSION" "$HEDGEDOC_REPOSITORY" /hedgedoc
 RUN git -C /hedgedoc log --pretty=format:'%ad %h %d' --abbrev-commit --date=short -1
 RUN git -C /hedgedoc rev-parse HEAD > /tmp/gitref


### PR DESCRIPTION
This PR removes the separate `basebuilder` step and speeds up the build a bit by not removing the `node_modules` folder in between `yarn install`s.