### PR TITLE
Add simple healthcheck

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -33,6 +33,10 @@ COPY --chown=$UID --from=builder /hedgedoc /hedgedoc
 # Add configuraton files
 COPY ["resources/config.json", "/files/"]
 
+# Healthcheck
+COPY --chown=$UID /resources/healthcheck.mjs /hedgedoc/healthcheck.mjs
+HEALTHCHECK --interval=5s CMD node healthcheck.mjs
+
 # For backwards compatibility
 RUN ln -s /hedgedoc /codimd
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -38,6 +38,10 @@ COPY --chown=$UID --from=builder /hedgedoc /hedgedoc
 # Add configuraton files
 COPY ["resources/config.json", "/files/"]
 
+# Healthcheck
+COPY --chown=$UID /resources/healthcheck.mjs /hedgedoc/healthcheck.mjs
+HEALTHCHECK --interval=5s CMD node healthcheck.mjs
+
 # For backwards compatibility
 RUN ln -s /hedgedoc /codimd
 

--- a/resources/healthcheck.mjs
+++ b/resources/healthcheck.mjs
@@ -1,0 +1,15 @@
+import fetch from 'node-fetch'
+
+// Kill myself after 5 second timeout
+setTimeout(() => {
+    process.exit(1)
+}, 5000)
+
+fetch(`http://localhost:${process.env.CMD_PORT || '3000' }/status`).then((response) => {
+    if (!response.ok) {
+        process.exit(1)
+    }
+    process.exit(0)
+}).catch(() => {
+    process.exit(1)
+})


### PR DESCRIPTION
This ports the healthcheck from https://github.com/hedgedoc/hedgedoc/pull/1228.

There was a short discussion in the dev chat, whether we want to include this by default.
The healthcheck seems to delay Traefik adding the container as a backend, but with the interval set to 5 seconds, this doesn't seem too big of a deal.
Also, as we currently don't recommend nor document a setup with Traefik, we can assume that someone who is using Traefik can also disable the healthcheck if they are bothered by it.