### PR TITLE
More Dockerfile cleanups

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -56,4 +56,4 @@ EXPOSE 3000
 COPY ["resources/docker-entrypoint.sh", "/usr/local/bin/docker-entrypoint.sh"]
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
-CMD ["npm", "start"]
+CMD ["node", "app.js"]

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -18,7 +18,6 @@ RUN jq ".repository.url = \"${HEDGEDOC_REPOSITORY}\"" /hedgedoc/package.json > /
 RUN mv /hedgedoc/package.new.json /hedgedoc/package.json
 
 # Install app dependencies and build
-RUN apt-get install --no-install-recommends -y bzip2
 WORKDIR /hedgedoc
 RUN yarn install --production=false --pure-lockfile
 RUN yarn run build

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -30,7 +30,7 @@ ARG UID=10000
 ENV NODE_ENV=production
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y fonts-noto gosu && \
+    apt-get install --no-install-recommends -y gosu && \
     rm -r /var/lib/apt/lists/*
 
 COPY --chown=$UID --from=builder /hedgedoc /hedgedoc

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -59,4 +59,4 @@ COPY ["resources/docker-entrypoint.sh", "/usr/local/bin/docker-entrypoint.sh"]
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
-CMD ["npm", "start"]
+CMD ["node", "app.js"]


### PR DESCRIPTION
This PR switches the start command to `node app.js` and removes two unneeded dependencies from the Debian image. See the commit messages for more details.