### PR TITLE
Fix chown issue on kaniko

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -28,6 +28,9 @@ FROM base
 ARG UID=10000
 ENV NODE_ENV=production
 
+# Create hedgedoc user
+RUN adduser -u $UID -h /hedgedoc/ -D -S hedgedoc
+
 COPY --chown=$UID --from=builder /hedgedoc /hedgedoc
 
 # Add configuraton files
@@ -46,9 +49,6 @@ RUN apk add --no-cache --no-progress --repository http://dl-cdn.alpinelinux.org/
 # Symlink configuration files
 RUN rm -f /hedgedoc/config.json
 RUN ln -s /files/config.json /hedgedoc/config.json
-
-# Create hedgedoc user
-RUN adduser -u $UID -h /hedgedoc/ -D -S hedgedoc
 
 WORKDIR /hedgedoc
 EXPOSE 3000

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -32,6 +32,9 @@ RUN apt-get update && \
     apt-get install --no-install-recommends -y gosu && \
     rm -r /var/lib/apt/lists/*
 
+# Create hedgedoc user
+RUN adduser --uid $UID --home /hedgedoc/ --disabled-password --system hedgedoc
+
 COPY --chown=$UID --from=builder /hedgedoc /hedgedoc
 
 # Add configuraton files
@@ -47,9 +50,6 @@ RUN ln -s /hedgedoc /codimd
 # Symlink configuration files
 RUN rm -f /hedgedoc/config.json
 RUN ln -s /files/config.json /hedgedoc/config.json
-
-# Create hedgedoc user
-RUN adduser --uid $UID --home /hedgedoc/ --disabled-password --system hedgedoc
 
 WORKDIR /hedgedoc
 EXPOSE 3000


### PR DESCRIPTION
This creates the hedgedoc user earlier as a workaround for https://github.com/GoogleContainerTools/kaniko/issues/1456.
This fix has a small impact and allow other people to build with kaniko (often used in gitlab).