### PR TITLE
feat(healthcheck): Add user-agent to healthcheck script

### DIFF
--- a/resources/healthcheck.mjs
+++ b/resources/healthcheck.mjs
@@ -5,7 +5,7 @@ setTimeout(() => {
     process.exit(1)
 }, 5000)
 
-fetch(`http://localhost:${process.env.CMD_PORT || '3000' }/status`).then((response) => {
+fetch(`http://localhost:${process.env.CMD_PORT || '3000' }/status`, {headers: { "user-agent": "hedgedoc-container-healthcheck/1.0"}}).then((response) => {
     if (!response.ok) {
         process.exit(1)
     }


### PR DESCRIPTION
This patch adds a custom user-agent to the healthcheck script to make it
more obvious in the logs where these requests come from. This was
requested by someone in the support chat.

It changes the regular log message from:
```
2021-12-11T14:12:03.339Z info: 	127.0.0.1 - - [11/Dec/2021:14:12:03 +0000] "GET /status HTTP/1.1" 200 266 "-" "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
```

To a more intuitive and readable user-agent:

```
2021-12-11T14:01:46.105Z info: 	127.0.0.1 - - [11/Dec/2021:14:01:46 +0000] "GET /status HTTP/1.1" 200 266 "-" "hedgedoc-container-healthcheck/1.0"
```

References:
https://matrix.to/#/!oaRMJImPLfUnnXzwnN:shivering-isles.com/$p-1lIoZ3HJG7nCEedeE16GjBPnkRT8jvERGGJ2dDrpk?via=matrix.org&via=kif.rocks&via=envs.net