### PR TITLE
Use utf8mb4 character set in MariaDB config

### DIFF
--- a/resources/utf8.cnf
+++ b/resources/utf8.cnf
@@ -1,11 +1,10 @@
 [client]
-default-character-set=utf8
+default-character-set=utf8mb4
 
 [mysql]
-default-character-set=utf8
-
+default-character-set=utf8mb4
 
 [mysqld]
-collation-server = utf8_unicode_ci
-init-connect='SET NAMES utf8'
-character-set-server = utf8
+collation-server = utf8mb4_unicode_ci
+init-connect='SET NAMES utf8mb4'
+character-set-server = utf8mb4


### PR DESCRIPTION
Since MariaDB 10.6 the 'utf8' character set is an alias for 'utf8mb3'.
This seems to trip up something, and HedgeDoc can't connect to the database anymore.

This PR changes the character set to 'utf8mb4', which is the "real" UTF-8 charset for MariaDB.
It should be backwards compatible with older *MariaDB versions*, the charset exists for a long time.

This will probably **break** existing *databases*, as the data in the tables needs to be manually converted (see https://mathiasbynens.be/notes/mysql-utf8mb4).

References:
https://mariadb.com/kb/en/upgrading-from-mariadb-105-to-mariadb-106/#character-sets
https://mariadb.com/kb/en/mariadb-1061-release-notes/#character-sets
https://mathiasbynens.be/notes/mysql-utf8mb4