### PR TITLE
ci(github-actions): Build multi-arch images for nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,7 +42,7 @@ jobs:
           labels: quay.expires-after=1w
           build-args: |
             VERSION=${{ env.HEDGEDOC_VERSION }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ env.HEDGEDOC_IMAGE }}:${{ env.TODAY }}-${{ matrix.base }}


### PR DESCRIPTION
This patch enabled multi-arch builds for nightly builds, this should
help to deploy hedgedoc on devices like a Raspberry Pi without resorting
to third-party images.

Initially, this should be done by nightly images, to evaluate if this
works properly. It can later-on be enabled on the general releases as
well.