### PR TITLE
Revert "feat: add armv7 and arm64 platforms"

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,7 +43,7 @@ jobs:
           labels: quay.expires-after=1w
           build-args: |
             VERSION=${{ env.HEDGEDOC_VERSION }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64
           push: true
           tags: |
             ${{ env.HEDGEDOC_IMAGE }}:${{ env.TODAY }}-${{ matrix.base }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,6 @@ jobs:
           file: ./${{ matrix.base }}/Dockerfile
           build-args: |
             VERSION=${{ env.HEDGEDOC_VERSION }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64
           push: true
           tags: ${{ env.TAGS }}


### PR DESCRIPTION
This reverts commit ce0a86b190346c762b94b10edf7cee354c872778 in favor of https://github.com/hedgedoc/container/pull/398