### PR TITLE
Added support for the _FILE Environment Variable Postfix

### DIFF
--- a/resources/docker-entrypoint.sh
+++ b/resources/docker-entrypoint.sh
@@ -51,6 +51,16 @@ if [ "$UID" -eq 0 ] && [ "$CMD_IMAGE_UPLOAD_TYPE" = "filesystem" ]; then
     fi
 fi
 
+#Add support for the _FILE Environment Variable Postfix
+FILE_ENV_VARS=$(printenv | grep "CMD_.*_FILE=.")
+for ENV_VAR in $FILE_ENV_VARS
+do
+    NEW_ENV_VAR=$(echo "$ENV_VAR" | grep -oE "(.+)=" | sed 's/_FILE=$//')
+    ENV_FILE_VAR_PATH=$(echo "$ENV_VAR" | grep -oE '=(.+)' | sed 's/^=//')
+    ENV_FILE_VAR_DATA=$(cat "$ENV_FILE_VAR_PATH")
+    export "$NEW_ENV_VAR"="$ENV_FILE_VAR_DATA"
+done
+
 # Sleep to make sure everything is fine...
 sleep 3
 


### PR DESCRIPTION
This adds a basic support for the `_FILE` Postfix commonly used for Environment Variables.
The Primary goal of this is to support the use of Docker secrets so that the Passwords are no longer contained in the compose file.

This approach uses the `docker-entrypoint.sh` to search for environment Variables with the `_FILE` Postfix.
It then creates new environment Variables without said Postfix where the value is set to the file contents.