### PR TITLE
Use /_health endpoint for healthcheck and decrease interval

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -39,7 +39,7 @@ COPY ["resources/config.json", "/files/"]
 
 # Healthcheck
 COPY --chown=$UID /resources/healthcheck.mjs /hedgedoc/healthcheck.mjs
-HEALTHCHECK --interval=5s CMD node healthcheck.mjs
+HEALTHCHECK --interval=15s CMD node healthcheck.mjs
 
 # For backwards compatibility
 RUN ln -s /hedgedoc /codimd

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -43,7 +43,7 @@ COPY ["resources/config.json", "/files/"]
 
 # Healthcheck
 COPY --chown=$UID /resources/healthcheck.mjs /hedgedoc/healthcheck.mjs
-HEALTHCHECK --interval=5s CMD node healthcheck.mjs
+HEALTHCHECK --interval=15s CMD node healthcheck.mjs
 
 # For backwards compatibility
 RUN ln -s /hedgedoc /codimd

--- a/resources/healthcheck.mjs
+++ b/resources/healthcheck.mjs
@@ -5,8 +5,13 @@ setTimeout(() => {
     process.exit(1)
 }, 5000)
 
-fetch(`http://localhost:${process.env.CMD_PORT || '3000' }/status`, {headers: { "user-agent": "hedgedoc-container-healthcheck/1.0"}}).then((response) => {
+fetch(`http://localhost:${process.env.CMD_PORT || '3000' }/_health`, {headers: { "user-agent": "hedgedoc-container-healthcheck/1.1"}}).then((response) => {
     if (!response.ok) {
+        process.exit(1)
+    }
+    return response.json()
+}).then((data) => {
+    if (!data.ready) {
         process.exit(1)
     }
     process.exit(0)


### PR DESCRIPTION
This PR changes the endpoint for the healthcheck from the more resource-hungry /status endpoint to /_health. It also decreases the interval to only check every 15 seconds instead of every 5 seconds to further reduce the load for the machine while keeping a reasonable interval.

This requires hedgedoc/hedgedoc#3450 as a pre-requisite
