### PR TITLE
Improve apk & apt pkg mgmt tool usage in Dockerfiles

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -12,8 +12,7 @@ RUN if [ -n "${CODIMD_REPOSITORY}" ]; then echo "CODIMD_REPOSITORY is deprecated
 
 # Clone the source and remove git repository but keep the HEAD file
 RUN --mount=target=/var/cache/apk,type=cache,sharing=locked \
-    apk update && \
-    apk add git jq python3 build-base
+    apk add --no-cache git jq python3 build-base
 RUN git clone --depth 1 --branch "$VERSION" "$HEDGEDOC_REPOSITORY" /hedgedoc
 RUN git -C /hedgedoc log --pretty=format:'%ad %h %d' --abbrev-commit --date=short -1
 RUN git -C /hedgedoc rev-parse HEAD > /tmp/gitref
@@ -36,8 +35,7 @@ ENV YARN_CACHE_FOLDER=/tmp/.yarn
 COPY --from=builder /hedgedoc /hedgedoc
 
 RUN --mount=target=/var/cache/apk,type=cache,sharing=locked \
-    apk update && \
-    apk add git python3 build-base
+    apk add --no-cache git python3 build-base
 
 RUN --mount=type=cache,sharing=locked,target=/tmp/.yarn yarn workspaces focus --production
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -40,7 +40,6 @@ COPY --from=builder /hedgedoc /hedgedoc
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     rm /var/lib/dpkg/info/libc-bin.* && \
-    apt-get clean && \
     apt-get update && \
     apt-get install --no-install-recommends -y git ca-certificates python-is-python3 build-essential
 


### PR DESCRIPTION
Use `apk add` command with `--no-cache` instead of an additional `apk update`, and remove the additional `apt-get clean`, which was also in the wrong place.


This change will ensure that no temporary files are left in the Docker images and remove unnecessary steps from the Dockerfiles.

Reference:
- https://docs.docker.com/build/building/best-practices/#apt-get

> Official Debian and Ubuntu images [automatically run `apt-get clean`](https://github.com/moby/moby/blob/03e2923e42446dbb830c654d0eec323a0b4ef02a/contrib/mkimage/debootstrap#L82-L105),so explicit invocation is not required.
