### PR TITLE
Add hardcoded but overridable gid

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -51,20 +51,22 @@ WORKDIR /hedgedoc
 
 ENV NODE_ENV=production
 ARG UID=10000
+ARG GID=10000
 ENV UPLOADS_MODE=0700
 
 RUN apk add --no-cache --no-progress --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ gosu
 
-# Create hedgedoc user
-RUN adduser -u $UID -h /hedgedoc/ -D -S hedgedoc
+# Create hedgedoc user and group
+RUN addgroup -g $GID hedgedoc && \
+    adduser -u $UID -h /hedgedoc/ -D -S hedgedoc -G hedgedoc
 
-COPY --chown=$UID --from=modules-installer /hedgedoc /hedgedoc
+COPY --chown=$UID:$GID --from=modules-installer /hedgedoc /hedgedoc
 
 # Add configuraton files
 COPY ["resources/config.json", "/files/"]
 
 # Healthcheck
-COPY --chown=$UID /resources/healthcheck.mjs /hedgedoc/healthcheck.mjs
+COPY --chown=$UID:$GID /resources/healthcheck.mjs /hedgedoc/healthcheck.mjs
 HEALTHCHECK --interval=15s CMD node healthcheck.mjs
 
 # For backwards compatibility

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -56,6 +56,7 @@ LABEL org.opencontainers.image.licenses='AGPL-3.0'
 WORKDIR /hedgedoc
 
 ARG UID=10000
+ARG GID=10000
 ENV NODE_ENV=production
 ENV UPLOADS_MODE=0700
 
@@ -63,16 +64,17 @@ RUN apt-get update && \
     apt-get install --no-install-recommends -y gosu && \
     rm -r /var/lib/apt/lists/*
 
-# Create hedgedoc user
-RUN adduser --uid $UID --home /hedgedoc/ --disabled-password --system hedgedoc
+# Create hedgedoc user and group
+RUN addgroup --gid $GID hedgedoc && \
+    adduser --uid $UID --ingroup hedgedoc --home /hedgedoc/ --disabled-password --system hedgedoc
 
-COPY --chown=$UID --from=modules-installer /hedgedoc /hedgedoc
+COPY --chown=$UID:$GID --from=modules-installer /hedgedoc /hedgedoc
 
 # Add configuraton files
 COPY ["resources/config.json", "/files/"]
 
 # Healthcheck
-COPY --chown=$UID /resources/healthcheck.mjs /hedgedoc/healthcheck.mjs
+COPY --chown=$UID:$GID /resources/healthcheck.mjs /hedgedoc/healthcheck.mjs
 HEALTHCHECK --interval=15s CMD node healthcheck.mjs
 
 # For backwards compatibility


### PR DESCRIPTION
Without a gid being set, some systems assign random numeric ids for a user's own group. By explicitly defining the gid alongside the uid, the behaviour is deterministic and local folder mounts can be prepared accordingly to have the right permissions.

Fixes #462 