### PR TITLE
fix(healthcheck): remove invalid node-fetch import

### DIFF
--- a/resources/healthcheck.mjs
+++ b/resources/healthcheck.mjs
@@ -1,11 +1,9 @@
-import fetch from 'node-fetch'
-
 // Kill myself after 5 second timeout
 setTimeout(() => {
     process.exit(1)
 }, 5000)
 
-fetch(`http://localhost:${process.env.CMD_PORT || '3000' }/_health`, {headers: { "user-agent": "hedgedoc-container-healthcheck/1.1"}}).then((response) => {
+fetch(`http://localhost:${process.env.CMD_PORT || '3000' }/_health`, {headers: { "user-agent": "hedgedoc-container-healthcheck/1.2"}}).then((response) => {
     if (!response.ok) {
         process.exit(1)
     }


### PR DESCRIPTION
We don't use node-fetch anymore since this is part of Node since v18 natively.